### PR TITLE
줄 끝 문자에 대한 .gitattributes 추가

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Aheui code files have line endings of lf
+*.aheui text eol=lf
+
+# Input and output files should not be changed
+*.in binary
+*.out binary


### PR DESCRIPTION
커밋하거나 클론할 때 줄 끝 문자가 바뀌어 테스트가 실패하는 경우가 있습니다.

아희 소스 코드의 경우 \r\n으로 받는 \n으로 받든 큰 상관은 없겠지만, 주로 쓰이는 줄 끝 문자인 \n으로 고정해 두었습니다.