### PR TITLE
AHEUI에 공백으로 구분되는 명령 허용

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -47,9 +47,9 @@ for d in $ds; do
         echo -n "  test $fbase"...
         if [ -e "$d/$fbase".out ]; then
             if [ -e "$d/$fbase".in ]; then
-                "$AHEUI" $AHEUIFLAGS "$f" < "$d/$fbase.in" > .test.tmp
+                $AHEUI $AHEUIFLAGS "$f" < "$d/$fbase.in" > .test.tmp
             else
-                "$AHEUI" $AHEUIFLAGS "$f" > .test.tmp
+                $AHEUI $AHEUIFLAGS "$f" > .test.tmp
             fi
             exitcode=$?
             out=`cat .test.tmp`


### PR DESCRIPTION
단일경로의 바이너리가 떨어지지 않는 인터프리터를 경유하는 스크립트 사용을 가능하도록 합니다 